### PR TITLE
Renaming CatalogRule -> Catalogrule to avoid problems on Linux systems s...

### DIFF
--- a/app/code/community/EcomDev/Varnish/Model/Catalogrule/Observer.php
+++ b/app/code/community/EcomDev/Varnish/Model/Catalogrule/Observer.php
@@ -1,6 +1,6 @@
 <?php
 
-class EcomDev_Varnish_Model_CatalogRule_Observer extends Mage_Core_Model_Abstract
+class EcomDev_Varnish_Model_Catalogrule_Observer extends Mage_Core_Model_Abstract
 {
     /**
      * List of affected product ids

--- a/app/code/community/EcomDev/Varnish/Model/Resource/Catalogrule/Observer.php
+++ b/app/code/community/EcomDev/Varnish/Model/Resource/Catalogrule/Observer.php
@@ -20,7 +20,7 @@
  * CatalogRule Observer resource model
  * 
  */
-class EcomDev_Varnish_Model_Resource_CatalogRule_Observer
+class EcomDev_Varnish_Model_Resource_Catalogrule_Observer
     extends Mage_Core_Model_Resource_Db_Abstract
 {
 


### PR DESCRIPTION
...ince *_catalogrule is used everywhere else and the uppercase R leads to errors
